### PR TITLE
Add new metric on CPU usage to detect burst usage

### DIFF
--- a/jobstats/templates/jobstats/job.html
+++ b/jobstats/templates/jobstats/job.html
@@ -325,9 +325,14 @@
       <td></td>
     </tr>
     <tr>
-      <td>{% translate "CPU cores" %}</td>
+      <td>{% translate "CPU cores (mean)" %}</td>
       <td>{{tres_req.total_cores}}</td>
       <td>{{cpu_used | floatformat:-2}}</td>
+    </tr>
+    <tr>
+      <td>{% translate "CPU cores (90th percentile)" %}</td>
+      <td>{{tres_req.total_cores}}</td>
+      <td>{{cpu_used_p90 | floatformat:-2}}</td>
     </tr>
     <tr>
       <td>{% translate "CPU cores by node" %}</td>


### PR DESCRIPTION
Ajout d'une métrique sur l'utilisation du CPU pour détecter l'utilisation en "burst". Certaines jobs sont faussement détecté comme gaspillage de ressource CPU parce que l'utilisation moyenne du CPU est < 50% même si le CPU est utlisé presque au maximun de manière sporadique. 

Solution:

- Ajout d'une nouvelle métrique CPU: 90e percentile.
- Ajout un critère à la condition de gaspillage: 90e percentile est supérieur à 75% des ressources alloué (donc le CPU est utilisé à plus de 75% pour 10% du temps)

Exemple de job avec faux possitif corrigé avec la nouvelle condition:
![screenshot](https://github.com/user-attachments/assets/330a33c6-47d7-4ebd-98b7-2f8bb7c37691)
![image](https://github.com/user-attachments/assets/ab8bf3eb-cfdf-474a-9ce5-774307177540)

